### PR TITLE
improve precision for metric timestamps

### DIFF
--- a/prometheus4j/src/main/java/com/tessell/prometheus4j/models/MatrixResponse.java
+++ b/prometheus4j/src/main/java/com/tessell/prometheus4j/models/MatrixResponse.java
@@ -30,7 +30,7 @@ public class MatrixResponse {
 
     public static class MatrixResult {
         Map<String, String> metric;
-        List<List<Float>> values;
+        List<List<Double>> values;
 
         public Map<String, String> getMetric() {
             return metric;
@@ -40,11 +40,11 @@ public class MatrixResponse {
             this.metric = metric;
         }
 
-        public List<List<Float>> getValues() {
+        public List<List<Double>> getValues() {
             return values;
         }
 
-        public void setValues(List<List<Float>> values) {
+        public void setValues(List<List<Double>> values) {
             this.values = values;
         }
 

--- a/prometheus4j/src/main/java/com/tessell/prometheus4j/models/PrometheusResponse.java
+++ b/prometheus4j/src/main/java/com/tessell/prometheus4j/models/PrometheusResponse.java
@@ -18,8 +18,8 @@ public class PrometheusResponse {
 
     class ResultItem {
         Map<String, String> metric;
-        List<Float> value;
-        List<List<Float>> values;
+        List<Double> value;
+        List<List<Double>> values;
 
         @Override
         public String toString() {

--- a/prometheus4j/src/main/java/com/tessell/prometheus4j/models/VectorResponse.java
+++ b/prometheus4j/src/main/java/com/tessell/prometheus4j/models/VectorResponse.java
@@ -9,7 +9,7 @@ public class VectorResponse {
 
     public static class VectorResult {
         private Map<String, String> metric;
-        private List<Float> value;
+        private List<Double> value;
 
         public Map<String, String> getMetric() {
             return metric;
@@ -19,11 +19,11 @@ public class VectorResponse {
             this.metric = metric;
         }
 
-        public List<Float> getValue() {
+        public List<Double> getValue() {
             return value;
         }
 
-        public void setValue(List<Float> value) {
+        public void setValue(List<Double> value) {
             this.value = value;
         }
 


### PR DESCRIPTION
Metric timestamps are currently stored and returned as float. This tends to reduce precision if multiple datapoints are reported within the same minute. We want to instead, store and manage these epoch timestamps in double format to retain better precision.