### PR TITLE
Added functions to get the raw API queries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 pluginVersion=1.0.0
-version=1.0.0
+version=1.0.1
 group=com.tessell
 systemProp.https.protocols=TLSv1.2
 nexus_repo_base=https://nexus.tessell.cloud/repository/

--- a/prometheus4j/pom.xml
+++ b/prometheus4j/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tessell</groupId>
     <artifactId>prometheus4j</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>prometheus4j</name>
     <description>Prometheus Java Client Library</description>
 

--- a/prometheus4j/src/main/java/com/tessell/prometheus4j/PrometheusApiClient.java
+++ b/prometheus4j/src/main/java/com/tessell/prometheus4j/PrometheusApiClient.java
@@ -3,6 +3,7 @@ package com.tessell.prometheus4j;
 import com.tessell.prometheus4j.models.KeyValResponse;
 import com.tessell.prometheus4j.models.MatrixResponse;
 import com.tessell.prometheus4j.models.VectorResponse;
+import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -18,9 +19,9 @@ public class PrometheusApiClient {
         this.baseUrl = baseUrl;
 
         this.retrofit = new Retrofit.Builder()
-            .baseUrl(baseUrl)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build();
+                .baseUrl(baseUrl)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
         service = retrofit.create(PrometheusRest.class);
     }
 
@@ -28,20 +29,44 @@ public class PrometheusApiClient {
         return service.query(query, null, null).execute().body();
     }
 
+    public String generateQueryApiUrl(String query) {
+        Call<VectorResponse> call = service.query(query, null, null);
+        return call.request().url().toString();
+    }
+
     public VectorResponse query(String query, String time) throws IOException {
         return service.query(query, time, null).execute().body();
+    }
+
+    public String generateQueryApiUrl(String query, String time) {
+        Call<VectorResponse> call = service.query(query, time, null);
+        return call.request().url().toString();
     }
 
     public VectorResponse query(String query, String time, String timeout) throws IOException {
         return service.query(query, time, timeout).execute().body();
     }
 
+    public String generateQueryApiUrl(String query, String time, String timeout) {
+        Call<VectorResponse> call = service.query(query, time, timeout);
+        return call.request().url().toString();
+    }
+
     public MatrixResponse queryRange(String query, String start, String end, String step, String timeout) throws IOException {
         return service.queryRange(query, start, end, step, timeout).execute().body();
+    }
+
+    public String generateQueryRangeApiUrl(String query, String start, String end, String step, String timeout) {
+        Call<MatrixResponse> call = service.queryRange(query, start, end, step, timeout);
+        return call.request().url().toString();
     }
 
     public KeyValResponse findSeries(String match, String start, String end) throws IOException {
         return service.findSeries(match, start, end).execute().body();
     }
 
+    public String generateFindSeriesApiUrl(String match, String start, String end) {
+        Call<KeyValResponse> call = service.findSeries(match, start, end);
+        return call.request().url().toString();
+    }
 }


### PR DESCRIPTION
Added functions to get the raw API queries
Prometheus4j inputs the promql based queries, converts them to Prometheus API calls and executes them.
Added functions to get the Prometheus API calls string instead of executing them, as these strings will be called locally on the victoria metrics vm using tgs.